### PR TITLE
Отладить ошибку appwrite

### DIFF
--- a/appwrite-config.js
+++ b/appwrite-config.js
@@ -16,11 +16,11 @@ let databases;
 
 function initAppwrite() {
     try {
-        client = new Client()
+        client = new Appwrite.Client()
             .setEndpoint(APPWRITE_ENDPOINT)
             .setProject(APPWRITE_PROJECT_ID);
         
-        databases = new Databases(client);
+        databases = new Appwrite.Databases(client);
         console.log('Appwrite клиент инициализирован');
         return true;
     } catch (error) {

--- a/appwrite-history.js
+++ b/appwrite-history.js
@@ -94,8 +94,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.meters,
                 [
-                    Query.equal('city_id', cityId),
-                    Query.equal('meter_type_id', meterTypeId)
+                    Appwrite.Query.equal('city_id', cityId),
+                    Appwrite.Query.equal('meter_type_id', meterTypeId)
                 ]
             );
 
@@ -111,10 +111,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.meterReadings,
                 [
-                    Query.equal('meter_id', meterIds),
-                    Query.greaterThanEqual('reading_date', fromDate),
-                    Query.lessThanEqual('reading_date', toDate),
-                    Query.orderDesc('reading_date')
+                    Appwrite.Query.equal('meter_id', meterIds),
+                    Appwrite.Query.greaterThanEqual('reading_date', fromDate),
+                    Appwrite.Query.lessThanEqual('reading_date', toDate),
+                    Appwrite.Query.orderDesc('reading_date')
                 ]
             );
 

--- a/appwrite-script.js
+++ b/appwrite-script.js
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const response = await databases.listDocuments(
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.meters,
-                [Query.equal('city_id', cityId)]
+                [Appwrite.Query.equal('city_id', cityId)]
             );
             
             const meters = response.documents;
@@ -126,9 +126,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.tariffs,
                 [
-                    Query.equal('city_id', cityId),
-                    Query.equal('meter_type_id', meterTypeId),
-                    Query.isNull('end_date')
+                    Appwrite.Query.equal('city_id', cityId),
+                    Appwrite.Query.equal('meter_type_id', meterTypeId),
+                    Appwrite.Query.isNull('end_date')
                 ]
             );
             
@@ -265,7 +265,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     await databases.createDocument(
                         APPWRITE_CONFIG.databaseId,
                         APPWRITE_CONFIG.collections.meterReadings,
-                        ID.unique(),
+                        Appwrite.ID.unique(),
                         reading
                     );
                     

--- a/appwrite-tariffs.js
+++ b/appwrite-tariffs.js
@@ -91,7 +91,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const response = await databases.listDocuments(
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.tariffs,
-                [Query.orderDesc('start_date')]
+                [Appwrite.Query.orderDesc('start_date')]
             );
             
             const tariffs = response.documents;
@@ -193,9 +193,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.tariffs,
                 [
-                    Query.equal('city_id', cityId),
-                    Query.equal('meter_type_id', meterTypeId),
-                    Query.isNull('end_date')
+                    Appwrite.Query.equal('city_id', cityId),
+                    Appwrite.Query.equal('meter_type_id', meterTypeId),
+                    Appwrite.Query.isNull('end_date')
                 ]
             );
             
@@ -216,7 +216,7 @@ document.addEventListener('DOMContentLoaded', function () {
             await databases.createDocument(
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.tariffs,
-                ID.unique(),
+                Appwrite.ID.unique(),
                 {
                     city_id: cityId,
                     meter_type_id: meterTypeId,

--- a/auth.html
+++ b/auth.html
@@ -322,7 +322,7 @@
                 hideMessages();
                 
                 // Создаем аккаунт
-                await account.create(ID.unique(), email, password, name);
+                await account.create(Appwrite.ID.unique(), email, password, name);
                 
                 // Автоматически входим
                 await account.createEmailPasswordSession(email, password);

--- a/init-data.js
+++ b/init-data.js
@@ -36,7 +36,7 @@ async function createCities() {
             const response = await databases.createDocument(
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.cities,
-                ID.unique(),
+                Appwrite.ID.unique(),
                 city
             );
             createdCities.push(response);
@@ -59,7 +59,7 @@ async function createMeterTypes() {
             const response = await databases.createDocument(
                 APPWRITE_CONFIG.databaseId,
                 APPWRITE_CONFIG.collections.meterTypes,
-                ID.unique(),
+                Appwrite.ID.unique(),
                 meterType
             );
             createdTypes.push(response);
@@ -91,7 +91,7 @@ async function createSampleMeters(cities, meterTypes) {
                 const response = await databases.createDocument(
                     APPWRITE_CONFIG.databaseId,
                     APPWRITE_CONFIG.collections.meters,
-                    ID.unique(),
+                    Appwrite.ID.unique(),
                     meterData
                 );
                 
@@ -130,7 +130,7 @@ async function createSampleTariffs(cities, meterTypes) {
                 const response = await databases.createDocument(
                     APPWRITE_CONFIG.databaseId,
                     APPWRITE_CONFIG.collections.tariffs,
-                    ID.unique(),
+                    Appwrite.ID.unique(),
                     tariffData
                 );
                 

--- a/script-appwrite.js
+++ b/script-appwrite.js
@@ -54,13 +54,13 @@ document.addEventListener('DOMContentLoaded', function () {
     // Функция для получения списка счетчиков по городу из Appwrite
     async function fetchMeters(cityId) {
         try {
-            const response = await databases.listDocuments(
-                DATABASE_ID,
-                METERS_COLLECTION_ID,
-                [
-                    Query.equal('city_id', cityId)
-                ]
-            );
+                            const response = await databases.listDocuments(
+                    DATABASE_ID,
+                    METERS_COLLECTION_ID,
+                    [
+                        Appwrite.Query.equal('city_id', cityId)
+                    ]
+                );
             
             if (response.documents && response.documents.length > 0) {
                 // Получаем типы счетчиков для отображения названий
@@ -79,8 +79,8 @@ document.addEventListener('DOMContentLoaded', function () {
                     DATABASE_ID,
                     TARIFFS_COLLECTION_ID,
                     [
-                        Query.equal('city_id', cityId),
-                        Query.equal('end_date', '')
+                        Appwrite.Query.equal('city_id', cityId),
+                        Appwrite.Query.equal('end_date', '')
                     ]
                 );
 
@@ -231,7 +231,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     await databases.createDocument(
                         DATABASE_ID,
                         METER_READINGS_COLLECTION_ID,
-                        ID.unique(),
+                        Appwrite.ID.unique(),
                         {
                             meter_id: reading.meterId,
                             reading_date: new Date().toISOString().split('T')[0],

--- a/test-appwrite.html
+++ b/test-appwrite.html
@@ -3,49 +3,34 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Тест подключения к Appwrite</title>
+    <title>Тест Appwrite</title>
     <style>
         body {
             font-family: Arial, sans-serif;
             max-width: 800px;
-            margin: 0 auto;
+            margin: 50px auto;
             padding: 20px;
         }
-        .test-section {
-            margin: 20px 0;
-            padding: 15px;
-            border: 1px solid #ddd;
+        .test-result {
+            padding: 10px;
+            margin: 10px 0;
             border-radius: 5px;
         }
-        .success {
-            background-color: #d4edda;
-            border-color: #c3e6cb;
-            color: #155724;
-        }
-        .error {
-            background-color: #f8d7da;
-            border-color: #f5c6cb;
-            color: #721c24;
-        }
-        .info {
-            background-color: #d1ecf1;
-            border-color: #bee5eb;
-            color: #0c5460;
-        }
+        .success { background: #d4edda; color: #155724; }
+        .error { background: #f8d7da; color: #721c24; }
+        .info { background: #d1ecf1; color: #0c5460; }
         button {
-            background-color: #007bff;
-            color: white;
-            border: none;
             padding: 10px 20px;
+            margin: 5px;
+            border: none;
             border-radius: 5px;
             cursor: pointer;
-            margin: 5px;
+            background: #007bff;
+            color: white;
         }
-        button:hover {
-            background-color: #0056b3;
-        }
+        button:hover { background: #0056b3; }
         pre {
-            background-color: #f8f9fa;
+            background: #f8f9fa;
             padding: 10px;
             border-radius: 5px;
             overflow-x: auto;
@@ -53,157 +38,78 @@
     </style>
 </head>
 <body>
-    <h1>Тест подключения к Appwrite</h1>
+    <h1>🧪 Тест инициализации Appwrite</h1>
     
-    <div class="test-section info">
-        <h3>Информация о подключении</h3>
-        <p><strong>Endpoint:</strong> https://cloud.appwrite.io/v1</p>
-        <p><strong>Project ID:</strong> 68790cc0001f9d5ee482</p>
-        <p><strong>Database ID:</strong> meter_readings_db</p>
+    <div id="config-info" class="test-result info">
+        <h3>Конфигурация:</h3>
+        <pre id="config-display"></pre>
     </div>
-
-    <div class="test-section">
-        <h3>Тест 1: Инициализация клиента</h3>
-        <button onclick="testClientInit()">Проверить инициализацию</button>
-        <div id="clientInitResult"></div>
+    
+    <div>
+        <button onclick="testInit()">Тест инициализации</button>
+        <button onclick="testConnection()">Тест подключения</button>
+        <button onclick="clearResults()">Очистить результаты</button>
     </div>
+    
+    <div id="results"></div>
 
-    <div class="test-section">
-        <h3>Тест 2: Подключение к базе данных</h3>
-        <button onclick="testDatabaseConnection()">Проверить подключение к БД</button>
-        <div id="dbConnectionResult"></div>
-    </div>
-
-    <div class="test-section">
-        <h3>Тест 3: Загрузка городов</h3>
-        <button onclick="testLoadCities()">Загрузить города</button>
-        <div id="citiesResult"></div>
-    </div>
-
-    <div class="test-section">
-        <h3>Тест 4: Загрузка типов счетчиков</h3>
-        <button onclick="testLoadMeterTypes()">Загрузить типы счетчиков</button>
-        <div id="meterTypesResult"></div>
-    </div>
-
-    <div class="test-section">
-        <h3>Тест 5: Загрузка счетчиков</h3>
-        <button onclick="testLoadMeters()">Загрузить счетчики</button>
-        <div id="metersResult"></div>
-    </div>
-
-    <div class="test-section">
-        <h3>Тест 6: Загрузка тарифов</h3>
-        <button onclick="testLoadTariffs()">Загрузить тарифы</button>
-        <div id="tariffsResult"></div>
-    </div>
-
-    <div class="test-section">
-        <h3>Тест 7: Загрузка показаний</h3>
-        <button onclick="testLoadReadings()">Загрузить показания</button>
-        <div id="readingsResult"></div>
-    </div>
-
-    <!-- Appwrite SDK -->
-    <script src="https://cdn.jsdelivr.net/npm/appwrite@11.0.0"></script>
-    <!-- Конфигурация Appwrite -->
+    <script src="https://cdn.jsdelivr.net/npm/appwrite@15.0.0"></script>
+    <script src="config.js"></script>
     <script src="appwrite-config.js"></script>
-
+    
     <script>
-        let client, databases;
-
-        function showResult(elementId, message, isSuccess = true) {
-            const element = document.getElementById(elementId);
-            element.innerHTML = `<pre>${message}</pre>`;
-            element.className = isSuccess ? 'success' : 'error';
+        // Отображение конфигурации
+        document.getElementById('config-display').textContent = 
+            JSON.stringify(APPWRITE_CONFIG, null, 2);
+        
+        function addResult(message, type = 'info') {
+            const results = document.getElementById('results');
+            const div = document.createElement('div');
+            div.className = `test-result ${type}`;
+            div.innerHTML = `<strong>[${new Date().toLocaleTimeString()}]</strong> ${message}`;
+            results.appendChild(div);
         }
-
-        async function testClientInit() {
+        
+        function testInit() {
+            addResult('🔌 Тестирование инициализации Appwrite...', 'info');
+            
             try {
-                if (initAppwrite()) {
-                    showResult('clientInitResult', '✅ Клиент Appwrite успешно инициализирован');
+                const result = initAppwrite();
+                if (result) {
+                    addResult('✅ Инициализация Appwrite прошла успешно!', 'success');
                 } else {
-                    showResult('clientInitResult', '❌ Ошибка инициализации клиента Appwrite', false);
+                    addResult('❌ Ошибка инициализации Appwrite', 'error');
                 }
             } catch (error) {
-                showResult('clientInitResult', `❌ Ошибка: ${error.message}`, false);
+                addResult(`❌ Ошибка инициализации: ${error.message}`, 'error');
+                console.error('Ошибка инициализации:', error);
             }
         }
-
-        async function testDatabaseConnection() {
+        
+        async function testConnection() {
+            addResult('🔌 Тестирование подключения к Appwrite...', 'info');
+            
             try {
+                if (!initAppwrite()) {
+                    throw new Error('Не удалось инициализировать Appwrite');
+                }
+                
+                // Простая проверка - попытка получить список баз данных
                 const response = await databases.list();
-                showResult('dbConnectionResult', `✅ Подключение к базе данных успешно\nНайдено баз данных: ${response.databases.length}\n\nДанные:\n${JSON.stringify(response, null, 2)}`);
+                addResult(`✅ Подключение успешно! Найдено баз данных: ${response.databases.length}`, 'success');
             } catch (error) {
-                showResult('dbConnectionResult', `❌ Ошибка подключения к базе данных: ${error.message}`, false);
+                addResult(`❌ Ошибка подключения: ${error.message}`, 'error');
+                console.error('Ошибка подключения:', error);
             }
         }
-
-        async function testLoadCities() {
-            try {
-                const response = await databases.listDocuments(
-                    DATABASE_ID,
-                    CITIES_COLLECTION_ID
-                );
-                showResult('citiesResult', `✅ Города загружены успешно\nКоличество: ${response.total}\n\nДанные:\n${JSON.stringify(response.documents, null, 2)}`);
-            } catch (error) {
-                showResult('citiesResult', `❌ Ошибка загрузки городов: ${error.message}`, false);
-            }
+        
+        function clearResults() {
+            document.getElementById('results').innerHTML = '';
         }
-
-        async function testLoadMeterTypes() {
-            try {
-                const response = await databases.listDocuments(
-                    DATABASE_ID,
-                    METER_TYPES_COLLECTION_ID
-                );
-                showResult('meterTypesResult', `✅ Типы счетчиков загружены успешно\nКоличество: ${response.total}\n\nДанные:\n${JSON.stringify(response.documents, null, 2)}`);
-            } catch (error) {
-                showResult('meterTypesResult', `❌ Ошибка загрузки типов счетчиков: ${error.message}`, false);
-            }
-        }
-
-        async function testLoadMeters() {
-            try {
-                const response = await databases.listDocuments(
-                    DATABASE_ID,
-                    METERS_COLLECTION_ID
-                );
-                showResult('metersResult', `✅ Счетчики загружены успешно\nКоличество: ${response.total}\n\nПервые 3 записи:\n${JSON.stringify(response.documents.slice(0, 3), null, 2)}`);
-            } catch (error) {
-                showResult('metersResult', `❌ Ошибка загрузки счетчиков: ${error.message}`, false);
-            }
-        }
-
-        async function testLoadTariffs() {
-            try {
-                const response = await databases.listDocuments(
-                    DATABASE_ID,
-                    TARIFFS_COLLECTION_ID
-                );
-                showResult('tariffsResult', `✅ Тарифы загружены успешно\nКоличество: ${response.total}\n\nПервые 3 записи:\n${JSON.stringify(response.documents.slice(0, 3), null, 2)}`);
-            } catch (error) {
-                showResult('tariffsResult', `❌ Ошибка загрузки тарифов: ${error.message}`, false);
-            }
-        }
-
-        async function testLoadReadings() {
-            try {
-                const response = await databases.listDocuments(
-                    DATABASE_ID,
-                    METER_READINGS_COLLECTION_ID
-                );
-                showResult('readingsResult', `✅ Показания загружены успешно\nКоличество: ${response.total}\n\nПервые 3 записи:\n${JSON.stringify(response.documents.slice(0, 3), null, 2)}`);
-            } catch (error) {
-                showResult('readingsResult', `❌ Ошибка загрузки показаний: ${error.message}`, false);
-            }
-        }
-
-        // Автоматический тест при загрузке страницы
-        window.addEventListener('load', function() {
-            setTimeout(() => {
-                testClientInit();
-            }, 1000);
+        
+        // Автоматический тест при загрузке
+        window.addEventListener('load', () => {
+            addResult('🚀 Страница загружена, готов к тестированию', 'info');
         });
     </script>
 </body>

--- a/test.html
+++ b/test.html
@@ -313,8 +313,8 @@
         // Инициализация клиента
         function initAppwrite() {
             try {
-                client = new Client();
-                databases = new Databases(client);
+                client = new Appwrite.Client();
+                databases = new Appwrite.Databases(client);
                 
                 client
                     .setEndpoint(APPWRITE_CONFIG.endpoint)
@@ -511,7 +511,7 @@
                 testDocument = await databases.createDocument(
                     APPWRITE_CONFIG.databaseId,
                     APPWRITE_CONFIG.collections.cities,
-                    ID.unique(),
+                    Appwrite.ID.unique(),
                     testData
                 );
                 
@@ -607,7 +607,7 @@
                 const metersResponse = await databases.listDocuments(
                     APPWRITE_CONFIG.databaseId,
                     APPWRITE_CONFIG.collections.meters,
-                    [Query.limit(1)]
+                    [Appwrite.Query.limit(1)]
                 );
                 
                 if (metersResponse.documents.length === 0) {
@@ -628,7 +628,7 @@
                 const reading = await databases.createDocument(
                     APPWRITE_CONFIG.databaseId,
                     APPWRITE_CONFIG.collections.meterReadings,
-                    ID.unique(),
+                    Appwrite.ID.unique(),
                     readingData
                 );
                 
@@ -667,7 +667,7 @@
                 const tariffsResponse = await databases.listDocuments(
                     APPWRITE_CONFIG.databaseId,
                     APPWRITE_CONFIG.collections.tariffs,
-                    [Query.limit(1)]
+                    [Appwrite.Query.limit(1)]
                 );
                 
                 if (tariffsResponse.documents.length === 0) {
@@ -694,7 +694,7 @@
                 const readingsResponse = await databases.listDocuments(
                     APPWRITE_CONFIG.databaseId,
                     APPWRITE_CONFIG.collections.meterReadings,
-                    [Query.limit(10)]
+                    [Appwrite.Query.limit(10)]
                 );
                 
                 log(`✅ История сгенерирована: найдено ${readingsResponse.documents.length} записей`);
@@ -744,7 +744,7 @@
                         await databases.listDocuments(
                             APPWRITE_CONFIG.databaseId,
                             id,
-                            [Query.limit(1)]
+                            [Appwrite.Query.limit(1)]
                         );
                         accessibleCollections++;
                     } catch (error) {


### PR DESCRIPTION
Fix Appwrite initialization error by ensuring correct Appwrite SDK class and method namespacing.

The error occurred because Appwrite SDK classes and methods were called directly (e.g., `new Client()`, `Query.equal()`) instead of through the `Appwrite` namespace (e.g., `new Appwrite.Client()`, `Appwrite.Query.equal()`).

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-9fa63b73-0201-4d4d-84c1-41ba895a7da6) · [Cursor](https://cursor.com/background-agent?bcId=bc-9fa63b73-0201-4d4d-84c1-41ba895a7da6)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)