### PR TITLE
Решить проблему отсутствия frontend в деплое

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Create deployment directory
       run: |
         mkdir -p deploy
-        cp -r frontend/* deploy/
+        cp -r *.html *.js *.css deploy/
         
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Fix deployment error by copying web files directly from root instead of a non-existent 'frontend' directory.

The previous `cp -r frontend/* deploy/` command failed because the `frontend` directory did not exist in the project structure, leading to a "No such file or directory" error during GitHub Actions deployment.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-da2ab237-24db-4c08-8bf2-43f209392c5f) · [Cursor](https://cursor.com/background-agent?bcId=bc-da2ab237-24db-4c08-8bf2-43f209392c5f)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)